### PR TITLE
explicitly state we have permission to use photo

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@ title: code4lib - Los Angeles 2017
 
 <div class="row attribution">
     <div class="container">
-        <p class="text-right small"><a href="https://www.flickr.com/photos/28794394@N03/13502778005/">photo: Ulysses Ebuen</a></p>
+        <p class="text-right small"><a href="https://www.flickr.com/photos/28794394@N03/13502778005/">photo by and with permission from Ulysses Ebuen</a></p>
     </div>
 </div>
 


### PR DESCRIPTION
Per discussion in chat, Joshua Gomez received permission from the photographer. Purpose of change is to make it clear to anybody who clicks through and sees that the photo is _not_ CC-licensed that we nonetheless have permission to use it.
